### PR TITLE
Fix sheet presentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 
 ### SwiftPackageManager ###
+.DS_Store
 Packages
 .build/
 xcuserdata

--- a/Sources/FlowStacks/Backport.swift
+++ b/Sources/FlowStacks/Backport.swift
@@ -1,0 +1,10 @@
+import Foundation
+import SwiftUI
+
+struct Backport<Content> {
+	let content: Content
+}
+
+extension View {
+	var backport: Backport<Self> { Backport(content: self) }
+}

--- a/Sources/FlowStacks/Node.swift
+++ b/Sources/FlowStacks/Node.swift
@@ -105,7 +105,7 @@ indirect enum Node<Screen, V: View>: View {
           onDismiss: onDismiss,
           content: { next }
         )
-        .cover(
+		.backport.cover(
           isPresented: coverBinding,
           onDismiss: onDismiss,
           content: { next }
@@ -117,7 +117,7 @@ indirect enum Node<Screen, V: View>: View {
           NavigationLink(destination: next, isActive: pushBinding, label: EmptyView.init)
             .hidden()
         )
-		.backported.present(
+		.backport.present(
           asSheet: asSheet,
           isPresented: asSheet ? sheetBinding : coverBinding,
           onDismiss: onDismiss,

--- a/Sources/FlowStacks/Node.swift
+++ b/Sources/FlowStacks/Node.swift
@@ -117,7 +117,7 @@ indirect enum Node<Screen, V: View>: View {
           NavigationLink(destination: next, isActive: pushBinding, label: EmptyView.init)
             .hidden()
         )
-        .present(
+		.backport.present(
           asSheet: asSheet,
           isPresented: asSheet ? sheetBinding : coverBinding,
           onDismiss: onDismiss,

--- a/Sources/FlowStacks/Node.swift
+++ b/Sources/FlowStacks/Node.swift
@@ -117,7 +117,7 @@ indirect enum Node<Screen, V: View>: View {
           NavigationLink(destination: next, isActive: pushBinding, label: EmptyView.init)
             .hidden()
         )
-		.backport.present(
+		.backported.present(
           asSheet: asSheet,
           isPresented: asSheet ? sheetBinding : coverBinding,
           onDismiss: onDismiss,

--- a/Sources/FlowStacks/Node.swift
+++ b/Sources/FlowStacks/Node.swift
@@ -111,15 +111,13 @@ indirect enum Node<Screen, V: View>: View {
           content: { next }
         )
     } else {
-      let asSheet = next?.route?.style.isSheet ?? false
       screenView
         .background(
           NavigationLink(destination: next, isActive: pushBinding, label: EmptyView.init)
             .hidden()
         )
 		.backport.present(
-          asSheet: asSheet,
-          isPresented: asSheet ? sheetBinding : coverBinding,
+          isPresented: sheetBinding,
           onDismiss: onDismiss,
           content: { next }
         )

--- a/Sources/FlowStacks/View+cover.swift
+++ b/Sources/FlowStacks/View+cover.swift
@@ -33,7 +33,7 @@ extension View {
   }
 }
 
-public extension Backport where Content: View {
+public extension Backported where Content: View {
 
 	  /// NOTE: On iOS 14.4 and below, a bug prevented multiple sheet/fullScreenCover modifiers being chained
 	  /// on the same view, so we conditionally add the sheet/cover modifiers as a workaround. See
@@ -61,10 +61,10 @@ public extension Backport where Content: View {
 	  }
 }
 
-public struct Backport<Content> {
+public struct Backported<Content> {
 	let content: Content
 }
 
 public extension View {
-	var backport: Backport<Self> { Backport(content: self) }
+	var backported: Backported<Self> { Backported(content: self) }
 }

--- a/Sources/FlowStacks/View+cover.swift
+++ b/Sources/FlowStacks/View+cover.swift
@@ -39,7 +39,7 @@ extension Backport where Content: View {
 			if #available(iOS 14.5, *) {
 				content.sheet(
 					isPresented: isPresented,
-					onDismiss: nil,
+					onDismiss: onDismiss,
 					content: contentBuilder
 				)
 			} else {
@@ -47,7 +47,7 @@ extension Backport where Content: View {
 					EmptyView()
 						.sheet(
 							isPresented: isPresented,
-							onDismiss: nil,
+							onDismiss: onDismiss,
 							content: contentBuilder
 						)
 				)

--- a/Sources/FlowStacks/View+cover.swift
+++ b/Sources/FlowStacks/View+cover.swift
@@ -38,11 +38,22 @@ extension View {
   @ViewBuilder
   func present<Content: View>(asSheet: Bool, isPresented: Binding<Bool>, onDismiss: (() -> Void)? = nil, @ViewBuilder content: @escaping () -> Content) -> some View {
     if asSheet {
-      self.sheet(
-        isPresented: isPresented,
-        onDismiss: nil,
-        content: content
-      )
+		if #available(iOS 14.5, *) {
+			self.sheet(
+				isPresented: isPresented,
+				onDismiss: nil,
+				content: content
+			)
+		} else {
+			self.background(
+				EmptyView()
+					.sheet(
+						isPresented: isPresented,
+						onDismiss: nil,
+						content: content
+					)
+			)
+		}
     } else {
       self.cover(
         isPresented: isPresented,

--- a/Sources/FlowStacks/View+cover.swift
+++ b/Sources/FlowStacks/View+cover.swift
@@ -31,35 +31,40 @@ extension View {
       }
     #endif
   }
+}
 
-  /// NOTE: On iOS 14.4 and below, a bug prevented multiple sheet/fullScreenCover modifiers being chained
-  /// on the same view, so we conditionally add the sheet/cover modifiers as a workaround. See
-  /// https://developer.apple.com/documentation/ios-ipados-release-notes/ios-ipados-14_5-release-notes
-  @ViewBuilder
-  func present<Content: View>(asSheet: Bool, isPresented: Binding<Bool>, onDismiss: (() -> Void)? = nil, @ViewBuilder content: @escaping () -> Content) -> some View {
-    if asSheet {
-		if #available(iOS 14.5, *) {
-			self.sheet(
-				isPresented: isPresented,
-				onDismiss: nil,
-				content: content
-			)
-		} else {
-			self.background(
-				EmptyView()
-					.sheet(
-						isPresented: isPresented,
-						onDismiss: nil,
-						content: content
-					)
-			)
-		}
-    } else {
-      self.cover(
-        isPresented: isPresented,
-        onDismiss: nil,
-        content: content
-      )
-    }
-  }
+public extension Backport where Content: View {
+
+	  /// NOTE: On iOS 14.4 and below, a bug prevented multiple sheet/fullScreenCover modifiers being chained
+	  /// on the same view, so we conditionally add the sheet/cover modifiers as a workaround. See
+	  /// https://developer.apple.com/documentation/ios-ipados-release-notes/ios-ipados-14_5-release-notes
+	  @ViewBuilder
+	  func present<Content: View>(asSheet: Bool, isPresented: Binding<Bool>, onDismiss: (() -> Void)? = nil, @ViewBuilder content contentBuilder: @escaping () -> Content) -> some View {
+
+			if #available(iOS 14.5, *) {
+				content.sheet(
+					isPresented: isPresented,
+					onDismiss: nil,
+					content: contentBuilder
+				)
+			} else {
+				content.background(
+					EmptyView()
+						.sheet(
+							isPresented: isPresented,
+							onDismiss: nil,
+							content: contentBuilder
+						)
+				)
+			}
+
+	  }
+}
+
+public struct Backport<Content> {
+	let content: Content
+}
+
+public extension View {
+	var backport: Backport<Self> { Backport(content: self) }
 }

--- a/Sources/FlowStacks/View+cover.swift
+++ b/Sources/FlowStacks/View+cover.swift
@@ -1,46 +1,42 @@
 import Foundation
 import SwiftUI
 
-extension View {
-  /// A shim for presenting a full-screen cover that falls back on a sheet presentation on platforms
-  /// where fullScreenCover is unavailable.
-  @ViewBuilder
-  func cover<Content: View>(isPresented: Binding<Bool>, onDismiss: (() -> Void)? = nil, @ViewBuilder content: @escaping () -> Content) -> some View {
-    #if os(macOS)
-      self
-        .sheet(
-          isPresented: isPresented,
-          onDismiss: onDismiss,
-          content: content
-        )
-    #else
-      if #available(iOS 14.0, tvOS 14.0, macOS 99.9, *) {
-        self
-          .fullScreenCover(
-            isPresented: isPresented,
-            onDismiss: onDismiss,
-            content: content
-          )
-      } else {
-        self
-          .sheet(
-            isPresented: isPresented,
-            onDismiss: onDismiss,
-            content: content
-          )
-      }
-    #endif
-  }
-}
+extension Backport where Content: View {
 
-public extension Backported where Content: View {
+	/// A shim for presenting a full-screen cover that falls back on a sheet presentation on platforms
+	/// where fullScreenCover is unavailable.
+	@ViewBuilder
+	func cover<Content: View>(isPresented: Binding<Bool>, onDismiss: (() -> Void)? = nil, @ViewBuilder content contentBuilder: @escaping () -> Content) -> some View {
+	  #if os(macOS)
+		self
+		  content.sheet(
+			isPresented: isPresented,
+			onDismiss: onDismiss,
+			content: content
+		  )
+	  #else
+		if #available(iOS 14.0, tvOS 14.0, macOS 99.9, *) {
+			content.fullScreenCover(
+			  isPresented: isPresented,
+			  onDismiss: onDismiss,
+			  content: contentBuilder
+			)
+		} else {
+			content.sheet(
+			  isPresented: isPresented,
+			  onDismiss: onDismiss,
+			  content: contentBuilder
+			)
+		}
+	  #endif
+	}
 
 	  /// NOTE: On iOS 14.4 and below, a bug prevented multiple sheet/fullScreenCover modifiers being chained
 	  /// on the same view, so we conditionally add the sheet/cover modifiers as a workaround. See
 	  /// https://developer.apple.com/documentation/ios-ipados-release-notes/ios-ipados-14_5-release-notes
 	  @ViewBuilder
 	  func present<Content: View>(asSheet: Bool, isPresented: Binding<Bool>, onDismiss: (() -> Void)? = nil, @ViewBuilder content contentBuilder: @escaping () -> Content) -> some View {
-
+		  if asSheet {
 			if #available(iOS 14.5, *) {
 				content.sheet(
 					isPresented: isPresented,
@@ -57,14 +53,13 @@ public extension Backported where Content: View {
 						)
 				)
 			}
-
+		  } else {
+			  cover(
+				isPresented: isPresented,
+				onDismiss: nil,
+				content: contentBuilder
+			  )
+		  }
 	  }
 }
 
-public struct Backported<Content> {
-	let content: Content
-}
-
-public extension View {
-	var backported: Backported<Self> { Backported(content: self) }
-}

--- a/Sources/FlowStacks/View+cover.swift
+++ b/Sources/FlowStacks/View+cover.swift
@@ -35,8 +35,7 @@ extension Backport where Content: View {
 	  /// on the same view, so we conditionally add the sheet/cover modifiers as a workaround. See
 	  /// https://developer.apple.com/documentation/ios-ipados-release-notes/ios-ipados-14_5-release-notes
 	  @ViewBuilder
-	  func present<Content: View>(asSheet: Bool, isPresented: Binding<Bool>, onDismiss: (() -> Void)? = nil, @ViewBuilder content contentBuilder: @escaping () -> Content) -> some View {
-
+	  func present<Content: View>(isPresented: Binding<Bool>, onDismiss: (() -> Void)? = nil, @ViewBuilder content contentBuilder: @escaping () -> Content) -> some View {
 			if #available(iOS 14.5, *) {
 				content.sheet(
 					isPresented: isPresented,
@@ -53,7 +52,6 @@ extension Backport where Content: View {
 						)
 				)
 			}
-
 	  }
 }
 

--- a/Sources/FlowStacks/View+cover.swift
+++ b/Sources/FlowStacks/View+cover.swift
@@ -36,7 +36,7 @@ extension Backport where Content: View {
 	  /// https://developer.apple.com/documentation/ios-ipados-release-notes/ios-ipados-14_5-release-notes
 	  @ViewBuilder
 	  func present<Content: View>(asSheet: Bool, isPresented: Binding<Bool>, onDismiss: (() -> Void)? = nil, @ViewBuilder content contentBuilder: @escaping () -> Content) -> some View {
-		  if asSheet {
+
 			if #available(iOS 14.5, *) {
 				content.sheet(
 					isPresented: isPresented,
@@ -53,13 +53,7 @@ extension Backport where Content: View {
 						)
 				)
 			}
-		  } else {
-			  cover(
-				isPresented: isPresented,
-				onDismiss: nil,
-				content: contentBuilder
-			  )
-		  }
+
 	  }
 }
 

--- a/Sources/FlowStacks/View+showing.swift
+++ b/Sources/FlowStacks/View+showing.swift
@@ -13,7 +13,7 @@ public extension View {
   /// - Parameter embedInNavigationView: Whether to embed the root screen in a navigation view.
   /// - Parameter buildView: A viewBuilder closure to build a view for a given screen binding and index. 
   /// - Returns: A view that will show the routes
-  func showing<Screen, ScreenView: View>(_ routes: Binding<[Route<Screen>]>, embedInNavigationView: Bool = false, @ViewBuilder buildViewBinding: @escaping (Binding<Screen>, Int) -> ScreenView) -> some View {
+  @MainActor func showing<Screen, ScreenView: View>(_ routes: Binding<[Route<Screen>]>, embedInNavigationView: Bool = false, @ViewBuilder buildViewBinding: @escaping (Binding<Screen>, Int) -> ScreenView) -> some View {
     return showing(routes, embedInNavigationView: embedInNavigationView, buildView: { screen, index in
       let screenBinding = Binding<Screen>(
         get: { routes.wrappedValue[index].screen },
@@ -29,7 +29,7 @@ public extension View {
   /// - Parameter embedInNavigationView: Whether to embed the root screen in a navigation view.
   /// - Parameter buildView: A viewBuilder closure to build a view for a given screen and index.
   /// - Returns: A view that will show the routes
-  func showing<Screen, ScreenView: View>(_ routes: Binding<[Route<Screen>]>, embedInNavigationView: Bool = false, @ViewBuilder buildView: @escaping (Screen, Int) -> ScreenView) -> some View {
+  @MainActor func showing<Screen, ScreenView: View>(_ routes: Binding<[Route<Screen>]>, embedInNavigationView: Bool = false, @ViewBuilder buildView: @escaping (Screen, Int) -> ScreenView) -> some View {
     let allScreens = Binding<[Route<AllScreen<Screen>>]>(
       get: {
         let root: Route<AllScreen<Screen>> = .root(AllScreen.root, embedInNavigationView: embedInNavigationView)


### PR DESCRIPTION
Hi there!

I have fixed the part of the implementation of this library where it shows the sheet to control iOS 14 bugs.

I have added the backport functionality as well as the workaround of using background with emptyView.

I have seen a strange behavior in the library in the use of asSheet to retrieve the style of the presentation that always returned false and tried to display in cover mode, so I have removed it as I don't see that it is necessary right now.